### PR TITLE
make migration generator work in Rails 4

### DIFF
--- a/generators/memento_migration/memento_migration_generator.rb
+++ b/generators/memento_migration/memento_migration_generator.rb
@@ -1,10 +1,14 @@
-class MementoMigrationGenerator < Rails::Generator::Base
-  def manifest
-    record do |m|
-      m.migration_template("migration.rb", 'db/migrate',
-                           :assigns => {  },
-                           :migration_file_name => "memento_migration"
-                           )
-    end
+require 'rails/generators'
+require 'rails/generators/active_record'
+
+class MementoMigrationGenerator < Rails::Generators::Base
+  include ::Rails::Generators::Migration
+  include ActiveRecord::Generators::Migration
+
+  source_root File.expand_path '../templates', __FILE__
+
+  def add_memento_migration
+    migration_template "migration.rb", 'db/migrate/memento_migration.rb'
   end
+
 end

--- a/generators/memento_migration/templates/migration.rb
+++ b/generators/memento_migration/templates/migration.rb
@@ -1,9 +1,9 @@
 class MementoMigration < ActiveRecord::Migration
 
-  def self.up
+  def change
     create_table :memento_sessions do |t|
       t.references :user
-      t.timestamps
+      t.timestamps null: false
     end
 
     create_table :memento_states do |t|
@@ -11,13 +11,8 @@ class MementoMigration < ActiveRecord::Migration
       t.binary :record_data, :limit => 16777215
       t.references :record, :polymorphic => true
       t.references :session
-      t.timestamps
+      t.timestamps null: false
     end
-  end
-
-  def self.down
-    drop_table :memento_states
-    drop_table :memento_sessions
   end
 
 end

--- a/lib/memento.rb
+++ b/lib/memento.rb
@@ -76,6 +76,7 @@ end
 def Memento(user_or_id, &block)
   Memento.watch(user_or_id, &block)
 end
+require 'memento/railtie'
 require 'memento/result'
 require 'memento/action'
 require 'memento/active_record_methods'

--- a/lib/memento/railtie.rb
+++ b/lib/memento/railtie.rb
@@ -1,0 +1,8 @@
+module Memento
+  class Railtie < Rails::Railtie
+    generators do
+      require File.join File.dirname(__FILE__), '..', '..', 'generators', 'memento_migration', 'memento_migration_generator'
+    end
+  end
+end
+


### PR DESCRIPTION
`rails g memento_migration` did not work for me on Rails 4.2.3 since the generator was not recognized. To make it work (and fix some deprecation warnings) I had to
- add a Railtie class
- fix the generator class
- update the migration (which I also converted to use #change instead up/down)
